### PR TITLE
Filter by field in wordpress entry

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -18,6 +18,10 @@ download_images: False
 # Item types we don't want to import.
 item_type_filter: {attachment, nav_menu_item}
 
+# filter by any field type on the post.
+# By default, we're filtering based on field "status" set to "draft"
+item_field_filter: {status: draft}
+
 taxonomies:
   # Filter taxonomies.
   filter: {}

--- a/exitwp.py
+++ b/exitwp.py
@@ -32,6 +32,7 @@ taxonomy_filter = set(config['taxonomies']['filter'])
 taxonomy_entry_filter = config['taxonomies']['entry_filter']
 taxonomy_name_mapping = config['taxonomies']['name_mapping']
 item_type_filter = set(config['item_type_filter'])
+item_field_filter = config['item_field_filter']
 date_fmt=config['date_format']
 
 def html2fmt(html, target_format):
@@ -227,6 +228,17 @@ def write_jekyll(data, target_format):
     #data['items']=[]
 
     for i in data['items']:
+
+        skip_item = False
+
+        for field, value in item_field_filter.iteritems():
+            if(i[field] == value):
+                skip_item = True
+                break
+
+        if(skip_item):
+            continue
+
         sys.stdout.write(".")
         sys.stdout.flush()
         out=None


### PR DESCRIPTION
Add the ability to filter out by fields on the wordpress entries.  I needed this because I had several 'draft' posts that had 0000-00-00 dates that couldn't be parsed correctly.

This also sets the default config to filter draft posts.
