### PR TITLE
Resolve taxonomy bugs

### DIFF
--- a/exitwp.py
+++ b/exitwp.py
@@ -281,6 +281,7 @@ def write_jekyll(data, target_format):
                 for tvalue in i['taxanomies'][taxonomy]:
                     t_name=taxonomy_name_mapping.get(taxonomy,taxonomy)
                     if t_name not in tax_out: tax_out[t_name]=[]
+                    if tvalue in tax_out[t_name]: continue
                     tax_out[t_name].append(tvalue)
 
             out.write('---\n')


### PR DESCRIPTION
1. I found that there are many empty domain categories in the taxonomy output, so I removed them.  I don't know what are the purposes to keep them.
2. When manipulating `tax_out`, don't append any taxonomies that are already in the corresponding `tax_out` array.
