### PR TITLE
Bump version of wp namespace from 1.1 to 1.2

### DIFF
--- a/exitwp.py
+++ b/exitwp.py
@@ -53,7 +53,7 @@ def parse_wp_xml(file):
         'content':"{http://purl.org/rss/1.0/modules/content/}",
         'wfw':"{http://wellformedweb.org/CommentAPI/}",
         'dc':"{http://purl.org/dc/elements/1.1/}",
-        'wp':"{http://wordpress.org/export/1.1/}",
+        'wp':"{http://wordpress.org/export/1.2/}",
         'atom':"{http://www.w3.org/2005/Atom}"
     }
 


### PR DESCRIPTION
Running exitwp on the xml file generated from a blog hosted on wordpress.com failed because wp namespace version changed.
