### PR TITLE
fixed issue #5

### DIFF
--- a/exitwp.py
+++ b/exitwp.py
@@ -53,7 +53,7 @@ def parse_wp_xml(file):
         'content':"{http://purl.org/rss/1.0/modules/content/}",
         'wfw':"{http://wellformedweb.org/CommentAPI/}",
         'dc':"{http://purl.org/dc/elements/1.1/}",
-        'wp':"{http://wordpress.org/export/1.2/}",
+        'wp':"{http://wordpress.org/export/1.1/}",
         'atom':"{http://www.w3.org/2005/Atom}"
     }
 


### PR DESCRIPTION
wordpress exports the xml namespace wp with the url http://wordpress.org/export/1.1/ ...
the code was expecting http://wordpress.org/export/1.2/

I am using the wordpress version 3.3.1, which is the latest as of today. I am not sure why your code expects 1.2. If its important, then maybe you would want to add to the readme to change the namespace url in the xml file... 
