### PR TITLE
fix yaml header problems

### DIFF
--- a/exitwp.py
+++ b/exitwp.py
@@ -255,9 +255,9 @@ def write_jekyll(data, target_format):
         out = None
         yaml_header = {
           'title': i['title'],
-          'date': i['date'],
+          'date': datetime.strptime(i['date'], '%Y-%m-%d %H:%M:%S'),
           'slug': i['slug'],
-          'wordpress_id': i['wp_id'],
+          'wordpress_id': int(i['wp_id']),
         }
         if i['status'] != u'publish':
             yaml_header['published'] = False


### PR DESCRIPTION
### published

When posts are private (for example), yaml should include 

``` yaml
published: false
```

but currently exitwp just add

``` yaml
status: private
```

which has no effect.
### date & wordpress_id

yaml.saft_dump() will add extra single quotation marks to string/unicode variable.
send the raw python type ( datetime for date, int for wordpress_id ) will fix this tiny problem.
