### PR TITLE
Add Comments support

### DIFF
--- a/exitwp.py
+++ b/exitwp.py
@@ -109,7 +109,6 @@ def parse_wp_xml(file):
             for key in body_replace:
                 body = body.replace(key, body_replace[key])
 
-
             img_srcs = []
             if body is not None:
                 try:


### PR DESCRIPTION
Currently exitwp doesn't specify comments status.
Which dafult is disable the comments.
We can judge the comments status according wp:comment_status
