### PR TITLE
Fixes crash when trying to print spanish accented characters.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ bin/
 build/
 include/
 .vagrant/
+.DS_Store

--- a/exitwp.py
+++ b/exitwp.py
@@ -117,7 +117,7 @@ def parse_wp_xml(file):
                     tag = q
                 try:
                     result = i.find(ns[namespace] + tag).text
-                    print result
+                    print result.encode('utf-8')
                 except AttributeError:
                     result = "No Content Found"
                 if unicode_wrap:


### PR DESCRIPTION
``` python
    Traceback (most recent call last):
      File "./exitwp.py", line 353, in <module>
        data = parse_wp_xml(wpe)
      File "./exitwp.py", line 164, in parse_wp_xml
        'items': parse_items(),
      File "./exitwp.py", line 127, in parse_items
        body = gi('content:encoded')
      File "./exitwp.py", line 120, in gi
        print result

    UnicodeEncodeError: 'ascii' codec can't encode character u'\xe1' in position 236: ordinal not in range(128)
```

Now is will display an encoding error on the writing of the files (not resulting on a crash anymore). 

```
writing............................................................................................
 Parse error on: Blog post title where the error happens
.................................
```

This fix could still be improved to fix the writing but don't really have the time right now.
