### PR TITLE
export source links to yaml header in markdown output

### DIFF
--- a/exitwp.py
+++ b/exitwp.py
@@ -152,6 +152,7 @@ def parse_wp_xml(file):
 
             export_item = {
                 'title': gi('title'),
+                'link': gi('link'),
                 'author': gi('dc:creator'),
                 'date': gi('wp:post_date_gmt'),
                 'slug': gi('wp:post_name'),
@@ -289,6 +290,7 @@ def write_jekyll(data, target_format):
         out = None
         yaml_header = {
             'title': i['title'],
+            'link': i['link'],
             'author': i['author'],
             'date': datetime.strptime(
                 i['date'], '%Y-%m-%d %H:%M:%S').replace(tzinfo=UTC()),


### PR DESCRIPTION
I think it is a good idea to have to original link url in the exported markdown ouput.
Example:
```
---
author: me
comments: true
date: 2015-12-19 11:21:23+00:00
layout: post
link: https://my-url.gobal.link/2015/12/foo-bar/
...
---

foobar
```

I'd be happy to see this merged. Thank you.
BTW. Thank you for exitwp!