### PR TITLE
Fix for "Error with time data"

### DIFF
--- a/exitwp.py
+++ b/exitwp.py
@@ -176,6 +176,11 @@ def parse_wp_xml(file):
         'items': parse_items(),
     }
 
+def format_date(date_text,date_format):
+    try:
+        datetime.strptime(date_text, date_format)
+    except ValueError:
+        'None'
 
 def write_jekyll(data, target_format):
 
@@ -292,8 +297,7 @@ def write_jekyll(data, target_format):
             'title': i['title'],
             'link': i['link'],
             'author': i['author'],
-            'date': datetime.strptime(
-                i['date'], '%Y-%m-%d %H:%M:%S').replace(tzinfo=UTC()),
+            'date': format_date(i['date'], '%Y-%m-%d %H:%M:%S'),
             'slug': i['slug'],
             'wordpress_id': int(i['wp_id']),
             'comments': i['comments'],


### PR DESCRIPTION
Automatically and silently default to "None" when an invalid date is encountered.
Resolves https://github.com/thomasf/exitwp/issues/70 as per discussion at https://stackoverflow.com/questions/45905739/valueerror-time-data-0000-00-00-000000-does-not-match-format-y-m-d-h/45905782#45905782