### PR TITLE
Specify yaml loader, to silence warning

### DIFF
--- a/exitwp.py
+++ b/exitwp.py
@@ -24,7 +24,7 @@ Tested with Wordpress 3.3.1 and jekyll 0.11.2
 ######################################################
 # Configration
 ######################################################
-config = yaml.load(file('config.yaml', 'r'))
+config = yaml.load(file('config.yaml', 'r'), Loader=yaml.FullLoader)
 wp_exports = config['wp_exports']
 build_dir = config['build_dir']
 download_images = config['download_images']


### PR DESCRIPTION
This avoids the following warning:

exitwp.py:27: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  config = yaml.load(file('config.yaml', 'r'))

Compare https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation